### PR TITLE
PHP 5.3 compatibility

### DIFF
--- a/Assetic/Filter/ConfigFilter.php
+++ b/Assetic/Filter/ConfigFilter.php
@@ -50,9 +50,11 @@ class ConfigFilter implements FilterInterface, HashableInterface
     }
 
     /**
-     * @param callable $encoder
+     * $encoder should be a PHP callable.
+     *
+     * @param mixed $encoder
      */
-    public function setEncoder(callable $encoder)
+    public function setEncoder($encoder)
     {
         $this->encoder = $encoder;
     }
@@ -72,16 +74,18 @@ class ConfigFilter implements FilterInterface, HashableInterface
         $content = $asset->getContent();
         $encoder = $this->encoder;
 
+        $parameterBag = $this->parameterBag;
+
         $content = preg_replace_callback(
             $this->configPattern,
-            function($matches) use ($encoder) {
+            function($matches) use ($encoder, $parameterBag) {
                 $parameter = $matches[1];
 
-                if (! $this->parameterBag->has($parameter)) {
+                if (! $parameterBag->has($parameter)) {
                     throw new Exception\ParameterNotFoundException("Parameter not found: '$parameter'.");
                 }
 
-                return $encoder($this->parameterBag->get($parameter));
+                return $encoder($parameterBag->get($parameter));
             },
             $content
         );

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": ">=2.3"
+        "symfony/symfony": ">=2.3",
+        "kriswallsmith/assetic": "~1.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~3.7"
     },
     "autoload": {
         "psr-0": { "Fazy\\AsseticConfigBundle": "" }


### PR DESCRIPTION
There are some php 5.4 artifacts inside the library that could easily be removed in order to make it 5.3 compatible. Since the composer.json for the package states that the minimum requirement is php 5.3.2, it seems that this should be a bug.

Also, I cleaned up the package dependencies. Tests can now be run cleanly after a composer install.